### PR TITLE
Fix import error

### DIFF
--- a/httpie_oauth2.py
+++ b/httpie_oauth2.py
@@ -7,7 +7,7 @@ from oauthlib.oauth2 import BackendApplicationClient, WebApplicationClient, Inse
 from requests_oauthlib import OAuth2Session
 from requests.auth import HTTPBasicAuth, AuthBase
 
-from httpie.cli import parser
+from httpie.cli.definition import parser
 
 from httpie.context import Environment
 


### PR DESCRIPTION
Seems like httpie moved the parser into `httpie.cli.definition`, simple fix. 